### PR TITLE
Switch to creating temp file instead of a var

### DIFF
--- a/.github/workflows/prepare-next-release.yml
+++ b/.github/workflows/prepare-next-release.yml
@@ -44,5 +44,16 @@ jobs:
 
       - run: |2
           set -e
-          export MERGES="$(git rev-list --merges --first-parent --reverse origin/master..origin/develop)"
+
+          HEAD=origin/develop
+          BASE=origin/master
+
+          commit_sha() { git log -1 --format='%H' $1; }
+
+          filename=$TMP/merges_$(commit_sha $BASE)_$(commit_sha $HEAD)
+
+          git rev-list $BASE..$HEAD --merges --first-parent --reverse > ${filename}
+
+          export MERGES="$(cat ${filename})"
+
           python scripts/gather-release-version.py


### PR DESCRIPTION
This is helpful because when creating a var, I have to use command substitution <code>$(<i>command</i>)</code>, which makes `set -e` to give no effect. When creating a file however, I have to use stdout redirection; with syntax, in case of error it will bubble up in the main shell, and `set -e` will perform fail-fast